### PR TITLE
SPECIFICALLY state ESP8266 is ONLY device supported for HEAP analysis

### DIFF
--- a/mongoose-os/userguide/debug.md
+++ b/mongoose-os/userguide/debug.md
@@ -77,8 +77,11 @@ Then from your apps' directory, do
 
 Heap log analyser is a tool developed by the Mongoose OS team. It is used
 for detecting memory leaks, and does it in a visual way, allowing to
-quickly pinpoint the place where a leak is happening. In order to use
-the heap log viewer, follow the steps below:
+quickly pinpoint the place where a leak is happening.
+
+ESP8266 is the only device this is supported on.
+
+In order to use the heap log viewer, follow the steps below:
 
 ### Enable heap log tracing
 


### PR DESCRIPTION
Wasted about 2 hours of my time flashing, collecting logs, then trying different devices and demo FW apps on ESP32 ....  **just to find out it is only supported on ESP8266.**  Would have been nice to know this before hand ... ugh