### PR TITLE
fixed dead links

### DIFF
--- a/mongoose-os/userguide/advanced.md
+++ b/mongoose-os/userguide/advanced.md
@@ -1,1 +1,0 @@
-See [advanced-c](advanced-c.md)

--- a/mongoose-os/userguide/build.md
+++ b/mongoose-os/userguide/build.md
@@ -56,7 +56,7 @@ author: Joe Bloggs <joe@bloggs.net>
 List of Makefile variables that are passed to the architecture-specific
 Makefile when an app is getting built. See next section for a build process
 deep-dive. An example of arch-specific Makefile is:
-[fw/platforms/esp32/Makefile.build](https://github.com/cesanta/mongoose-os/blob/master/fw/platforms/esp32/Makefile.build).
+[platforms/esp32/Makefile.build](https://github.com/cesanta/mongoose-os/blob/master/platforms/esp32/Makefile.build).
 The others are in the respective directories: `fw/platforms/*/Makefile.build`.
 
 The example below changes ESP32 SDK configuration by disabling brownout detection:
@@ -328,7 +328,7 @@ libs:
   with the FFI JS wrappers.
 - Build / test `myapp` until it works.
 - See example libraries at
-  https://mongoose-os.com/docs/reference/api.html#hardware
+  https://mongoose-os.com/docs/mongoose-os/api/arduino/arduino-adafruit-ads1x15.md
 
 ## Contributing an app or library
 
@@ -344,6 +344,6 @@ please follow these steps:
     - If it is a port of an Arduino library, make sure you include `arduino-compat` library in `mos.yml` file, see [arduino-adafruit-ssd1306 lib](https://github.com/mongoose-os-libs/arduino-adafruit-ssd1306/blob/master/mos.yml) for an example
     - See https://github.com/mongoose-os-libs/blynk for the reference
     - Consider contributing an example app that uses your library
-- [Start a new discussion on forum](https://forum.mongoose-os.com/post/discussion/mongoose-iot) with a subject `New contribution: ...`,
+- [Start a new discussion on forum](https://community.mongoose-os.com/) with a subject `New contribution: ...`,
 	show a link to your code on GitHub / Bitbucket / whatever, or
 	attach a zip file with the app sources.

--- a/mongoose-os/userguide/configuration.md
+++ b/mongoose-os/userguide/configuration.md
@@ -93,12 +93,10 @@ Configuration is defined by several YAML files in the Mongoose OS source
 repository. Each Mongoose OS module, for example, crypto chip support module,
 can define it's own section in the configuration. Here are few examples:
 
-- [mgos_sys_config.yaml](https://github.com/cesanta/mongoose-os/blob/master/fw/src/mgos_sys_config.yaml) is core module, defines debug settings, etc
-- [mgos_atca_config.yaml](https://github.com/cesanta/mongoose-os/blob/master/fw/src/mgos_atca_config.yaml) is a crypto chip support module
-- [mgos_mqtt_config.yaml](https://github.com/cesanta/mongoose-os/blob/master/fw/src/mgos_mqtt_config.yaml) has default MQTT server settings
+- [mgos_sys_config.yaml](https://github.com/mongoose-os-libs/core/blob/master/mos.yml) is core module, defines debug settings, etc
+- [mgos_atca_config.yaml](https://github.com/mongoose-os-libs/atca/blob/master/mos.yml) is a crypto chip support module
+- [mgos_mqtt_config.yaml](https://github.com/mongoose-os-libs/mqtt/blob/master/mos.yml) has default MQTT server settings
 
-There are more, you can see them all at
-[fw/src](https://github.com/cesanta/mongoose-os/tree/master/fw/src) directory.
 
 As has been mentioned in the overview, you can define your own sections in
 the config, or override existing default values. This is done by placing a
@@ -110,18 +108,13 @@ config_schema:
   - ["hello.who", "s", "world", {"title": "Who to say hello to"}]
 ```
 
-The snippet above is from [fw/examples/c_hello](https://github.com/cesanta/mongoose-os/tree/master/fw/examples/c_hello/mos.yml)
-example.
-
 When the firmware is built, all these YAML files get merged into one.
 User-specified YAML file goes last, therefore it can override any other.
 Then, merged YAML file gets translated into two C files, `mgos_config.h` and
 and `mgos_config.c`. You can find these generated files in the
 `YOUR_FIRMWARE_DIR/build/gen/` directory after you build your firmware.
 
-Here's a translation example, taken from
-[fw/examples/c_hello](https://github.com/cesanta/mongoose-os/tree/master/fw/examples/c_hello).
-There, we have a custom `src/conf_schema.yaml`:
+Here's a translation example of a custom `src/conf_schema.yaml`:
 
 ```yaml
 [
@@ -137,13 +130,13 @@ const char *mgos_sys_config_get_hello_who(void);
 void        mgos_sys_config_set_hello_who(const char *val);
 ```
 
-Then, C firmware code in [src/main.c](https://github.com/cesanta/mongoose-os/tree/master/fw/examples/c_hello/src/main.c) accesses that custom configuration value:
+Then, C firmware code can accesses that custom configuration value:
 
 ```c
   printf("Hello, %s!\n", mgos_sys_config_get_hello_who());
 ```
 
-Numbers are represented by integers, as are booleans.
+Numbers are represented by integers in C, as are booleans.
 Strings will be allocated on the heap.
 
 **IMPORTANT NOTE**: Empty strings will be represented as `NULL` pointers,

--- a/mongoose-os/userguide/intro.md
+++ b/mongoose-os/userguide/intro.md
@@ -66,11 +66,10 @@ networking API, etc, will be covered further down.
 The Mongoose OS core lives at
 [cesanta/mongoose-os](https://github.com/cesanta/mongoose-os) on GitHub:
 
-- [common/](https://github.com/cesanta/mongoose-os/tree/master/common) - various utility functions
-- [fw/src/](https://github.com/cesanta/mongoose-os/tree/master/fw/src) - cross-platform API
-- [fw/platforms/](https://github.com/cesanta/mongoose-os/tree/master/fw/platforms) - platform-specific code
-- [frozen/](https://github.com/cesanta/mongoose-os/tree/master/frozen) - JSON parser/emitter
-- [mongoose/](https://github.com/cesanta/mongoose-os/tree/master/mongoose) - networking code
+- [src/](https://github.com/cesanta/mongoose-os/tree/master/src) - cross-platform API
+- [src/common/](https://github.com/cesanta/mongoose-os/tree/master/src/common) - various utility functions
+- [src/frozen/](https://github.com/cesanta/mongoose-os/tree/master/src/frozen) - JSON parser/emitter
+- [platforms/](https://github.com/cesanta/mongoose-os/tree/master/platforms) - platform-specific code
 
 The bulk of the functionality, however, is split into libraries. Each library
 is a separate GitHub repository, collected under the
@@ -96,7 +95,7 @@ documentation page. The content is generate from the README.md and header files.
 ## Boot process
 
 The boot process is driven by a cross-platform
-[mgos_init.c](https://github.com/cesanta/mongoose-os/blob/master/fw/src/mgos_init.c).
+[mgos_init.c](https://github.com/cesanta/mongoose-os/blob/master/src/mgos_init.c).
 In short, the subsystems are initialised in the following order:
 
 Native SDK init, GPIO, configuration, WiFi, platform-specific init,
@@ -189,7 +188,7 @@ function defined in `mgos_mongoose.h`.
 
 Note that `mgos_` API, as well as `mg_` API, is cross-platform. A firmware
 written with that API only, is portable between supported architectures,
-as demonstrated by many [example apps](https://mongoose-os/docs/reference/apps.html).
+as demonstrated by many [example apps](https://github.com/mongoose-os-apps).
 However, the native SDK API is not in any way hidden and is fully available.
 For example, one could fire extra FreeRTOS tasks on platforms whose SDK
 use FreeRTOS. The price to pay is loss of portability.

--- a/mongoose-os/userguide/security.md
+++ b/mongoose-os/userguide/security.md
@@ -127,7 +127,7 @@ Note 2: Sample config is very permissive and is only
   suitable for development and testing, NOT for production deployments. Please refer to 
   Microchip's manual and other documentation to come up with more secure
   configuration (we may be able to assist with that too - ask a question
-  on [our forum](http://forum.cesanta.com)).
+  on [our forum](https://community.mongoose-os.com/)).
 
 2. Generate a cert and key as normal. An example below shows a self-signed 
   certificate, but of course it doesn't have to be. The importnat thing is


### PR DESCRIPTION
Hi guys, 

I fixed a bunch of dead links in the docs. At the moment, I think I have everything in the mongoose-os/userguide directory, apart from the 'commercial.md' page, which I figure is not a community task :)

Anyway, hope to get around to the rest, if it's ok with you all...

In case there is interest, I could work some tests that check for dead links to run in travis or whatever.