### PR TITLE
Update mdash-setup format

### DIFF
--- a/mongoose-os/quickstart/setup.md
+++ b/mongoose-os/quickstart/setup.md
@@ -134,7 +134,7 @@ network, gets the IP configuration, and synchronises time with SNTP server:
 
 - Go back to the mos tool, type command (change TOKEN to your copied token) and press enter:
   ```
-  mos mdash-setup d1 TOKEN
+  mos mdash-setup TOKEN
   ```
 
 The `d1` in a command above is device ID.


### PR DESCRIPTION
`mdash-setup` does not need `device_id` anymore.