### PR TITLE
Fixed links to Logging header/source files.

### DIFF
--- a/mongoose-os/api/core/cs_dbg.h.md
+++ b/mongoose-os/api/core/cs_dbg.h.md
@@ -1,7 +1,7 @@
 # Logging
 | Github Repo | C Header | C source  | JS source |
 | ----------- | -------- | --------  | ----------------- |
-| [cesanta/mongoose-os](https://github.com/cesanta/mongoose-os) | [cs_dbg.h](https://github.com/cesanta/mongoose-os/blob/master/include/cs_dbg.h) | [cs_dbg.c](https://github.com/cesanta/mongoose-os/blob/master/src/cs_dbg.c)  | &nbsp;         |
+| [cesanta/mongoose-os](https://github.com/cesanta/mongoose-os) | [cs_dbg.h](https://github.com/cesanta/mongoose-os/blob/master/include/common/cs_dbg.h) | [cs_dbg.c](https://github.com/cesanta/mongoose/blob/master/src/common/cs_dbg.c)  | &nbsp;         |
 
 #### cs_log_set_level
 


### PR DESCRIPTION
`cs_dbg.h` was moved to include/common in
https://github.com/cesanta/mongoose-os/commit/1236cde805bd6dfaee53b5a1e0116d3e837138a8
and `cs_dbg.c` was deleted. Correcting documentation links.